### PR TITLE
Declaring #include <sys/time.h>

### DIFF
--- a/examples/VGA/MultitaskingCPM/src/HAL.h
+++ b/examples/VGA/MultitaskingCPM/src/HAL.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <stdio.h>
+#include <sys/time.h>
 
 #include "emudevs/Z80.h"
 


### PR DESCRIPTION
Declaring #include <sys/time.h> here instead of inside HAL.cpp to fix compile errors.