### PR TITLE
Adds HDMI compatibility via VGA to HDMI adapters

### DIFF
--- a/examples/VGA/PCEmulator/PCEmulator.ino
+++ b/examples/VGA/PCEmulator/PCEmulator.ino
@@ -259,8 +259,18 @@ void setup()
   // uncomment to clear preferences
   //preferences.clear();
 
-  ibox.begin(VGA_640x400_70Hz, 400, 300); // VGA_640x400_60Hz as alternative?
+  ibox.begin(VGA_640x480_60Hz, 400, 300); // Using VGA_640x480_60Hz as it's very compatible and allows many VGA to HDMI adapters to display the UI
   ibox.setBackgroundColor(RGB888(0, 0, 0));
+
+  // ask if a HDMI adapter is connected, if it is then the GraphicsAdapter will need to run in HDMICompat mode
+  const unsigned int INVALIDVAL = 3;
+  unsigned int hdmiAdapterInUse = preferences.getUInt("hdmiAdapter", INVALIDVAL);
+  if (hdmiAdapterInUse == INVALIDVAL)
+  {
+    // value is unset, ask user
+    hdmiAdapterInUse = ibox.message("Display configuration", "Are you using a VGA to HDMI converter?", "Yes", "No") == InputResult::Enter ? 0 : 1;
+    preferences.putUInt("hdmiAdapter", hdmiAdapterInUse);
+  }
 
   // we need PSRAM for this app, but we will handle it manually, so please DO NOT enable PSRAM on your development env
   #ifdef BOARD_HAS_PSRAM
@@ -333,7 +343,7 @@ void setup()
   ibox.end();
 
 
-  machine = new Machine;
+  machine = new Machine(hdmiAdapterInUse);
   machine->setDriveA(filenameDiskA);
   machine->setDriveC(filenameDiskC);
   machine->run();

--- a/examples/VGA/PCEmulator/machine.cpp
+++ b/examples/VGA/PCEmulator/machine.cpp
@@ -95,7 +95,8 @@ uint8_t *         Machine::s_memory;
 uint8_t *         Machine::s_videoMemory;
 
 
-Machine::Machine()
+Machine::Machine(bool hdmiAdapterInUse)
+: m_graphicsAdapter(hdmiAdapterInUse)
 {
 }
 

--- a/examples/VGA/PCEmulator/machine.h
+++ b/examples/VGA/PCEmulator/machine.h
@@ -60,7 +60,7 @@ using fabgl::MCP23S17;
 class Machine {
 
 public:
-  Machine();
+  Machine(bool hdmiAdapterInUse);
   ~Machine();
 
   void setDriveA(char const * filename) { m_diskImageFile[1] = filename; }

--- a/src/emudevs/graphicsadapter.h
+++ b/src/emudevs/graphicsadapter.h
@@ -57,8 +57,14 @@ public:
     PC_Graphics_HGC_720x348,      // Hercules 720x348 Graphics Black/White
   };
 
-
-  GraphicsAdapter();
+  /**
+   * @brief Construct a new GraphicsAdapter
+   *
+   *
+   * @param enableHDMICompatibility If true then text, 320x200 and 640x200 modes are rescaled to 640x480x60hz to enable compatibility with many VGA to HDMI adapters
+   *
+   */
+  GraphicsAdapter(bool enableHDMICompatibility);
   ~GraphicsAdapter();
 
   void setEmulation(Emulation emulation);
@@ -97,10 +103,13 @@ private:
 
   static void drawScanline_PC_Text_80x25_16Colors(void * arg, uint8_t * dest, int scanLine);
   static void drawScanline_PC_Text_40x25_16Colors(void * arg, uint8_t * dest, int scanLine);
+  static void drawScanline_PC_Text_80x25_16Colors_HDMICompat(void * arg, uint8_t * dest, int scanLine);
   static void drawScanline_PC_Graphics_320x200_4Colors(void * arg, uint8_t * dest, int scanLine);
+  static void drawScanline_PC_Graphics_320x200_4Colors_HDMICompat(void * arg, uint8_t * dest, int scanLine);
   static void drawScanline_PC_Graphics_640x200_2Colors(void * arg, uint8_t * dest, int scanLine);
   static void drawScanline_PC_Graphics_HGC_720x348(void * arg, uint8_t * dest, int scanLine);
 
+  bool                m_hdmiCompatMode;
 
   VGADirectController m_VGADCtrl;
   Emulation           m_emulation;


### PR DESCRIPTION
This PR enables HDMI compatibility mode. In this mode a number of common VGA to HDMI adapters can be used to render output on modern devices at 640x480x60hz. Although most HDMI adapters don't say they work at this res many do. Currently if you plug a TTGO VGA32 1.4 flashed with the PC Emulator sketch into one of these you get a black screen - not good.

This PR:
- Fixes the default resolution for the menu and asks the user if they have an adapter in place
- Sets up HDMI compat mode which changes most resolutions to actually render at 640x480 @ 60Hz
- Fixes lower resolutions but adding black bars and if possible doubling width and height (works well)

It does not currently work on PC_Graphics_HGC_720x348 as we would need an SVGA res.

Tested with 2 cheap Amazon HDMI adapters (one with 3.5mm sound adapter) both worked on Dell 4k ultrawide monitor.

Fixed https://github.com/fdivitto/FabGL/issues/140

(I saw that you don't want pull requests. Well here is one anyway. Is this for a licensing thing? You can have this code under your license.)