### PR TITLE
Compile with pure IDF

### DIFF
--- a/src/fabutils.h
+++ b/src/fabutils.h
@@ -47,6 +47,8 @@
 
 #ifdef ARDUINO
 #include "Arduino.h"
+#else
+#include <cstring>
 #endif
 
 


### PR DESCRIPTION
Hi, it seems on the latest IDF that `cstring` is needed for the helpers.