### PR TITLE
Fix compiler error due to missing `strlen`

### DIFF
--- a/src/fabutils.h
+++ b/src/fabutils.h
@@ -35,6 +35,7 @@
  *
  */
 
+#include <cstring>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"


### PR DESCRIPTION
Tested on ESP-IDF v4.4