### PR TITLE
Fix of (will be initialized after [-Werror=reorder]) error

### DIFF
--- a/examples/VGA/PCEmulator/machine.cpp
+++ b/examples/VGA/PCEmulator/machine.cpp
@@ -100,8 +100,8 @@ Machine::Machine() :
     m_stepCallback(nullptr),
     #endif
     m_diskFilename(),
-    m_disk(),
     m_diskChanged(),
+    m_disk(),
     m_frameBuffer(nullptr),
     m_bootDrive(0),
     m_sysReqCallback(nullptr),


### PR DESCRIPTION
Fix of `...will be initialized after [-Werror=reorder]` error, (e.g. when Arduino IDE 2.0 warning level set to `More`).