### PR TITLE
Esp32 UART2 enabled as COM2 for PC Emulator

### DIFF
--- a/examples/VGA/PCEmulator/machine.cpp
+++ b/examples/VGA/PCEmulator/machine.cpp
@@ -100,8 +100,8 @@ Machine::Machine() :
     m_stepCallback(nullptr),
     #endif
     m_diskFilename(),
-    m_disk(),
     m_diskChanged(),
+    m_disk(),
     m_frameBuffer(nullptr),
     m_bootDrive(0),
     m_sysReqCallback(nullptr),
@@ -192,6 +192,12 @@ void Machine::setDriveImage(int drive, char const * filename, int cylinders, int
         autoDetectDriveGeometry(drive);
     }
   }
+}
+
+
+bool Machine::isFabGlDevelopmentBoard()
+{
+  return m_MCP23S17.isChipPackageFabGlDevelopmentBoard();
 }
 
 

--- a/examples/VGA/PCEmulator/machine.h
+++ b/examples/VGA/PCEmulator/machine.h
@@ -76,6 +76,8 @@ public:
   void setBaseDirectory(char const * value)    { m_baseDir = value; }
 
   void setDriveImage(int drive, char const * filename, int cylinders = 0, int heads = 0, int sectors = 0);
+
+  bool isFabGlDevelopmentBoard();
   
   bool diskChanged(int drive)                  { return m_diskChanged[drive]; }
   void resetDiskChanged(int drive)             { m_diskChanged[drive] = false; }

--- a/src/devdrivers/MCP23S17.cpp
+++ b/src/devdrivers/MCP23S17.cpp
@@ -49,6 +49,10 @@ MCP23S17::~MCP23S17()
   end();
 }
 
+bool MCP23S17::isChipPackageFabGlDevelopmentBoard()
+{
+  return (getChipPackage() == ChipPackage::ESP32D0WDQ5);
+}
 
 bool MCP23S17::begin(int MISO, int MOSI, int CLK, int CS, int CSActiveState, int host)
 {

--- a/src/devdrivers/MCP23S17.h
+++ b/src/devdrivers/MCP23S17.h
@@ -207,6 +207,12 @@ public:
    */
   bool initDevice(uint8_t hwAddr);
 
+  /**
+   * @brief FabGL board detection
+   *
+   * @return True if the board is FabGL dev-board.
+   */
+bool isChipPackageFabGlDevelopmentBoard();
 
   //// registers read/write ////
 


### PR DESCRIPTION
By default, COM2 is disabled: `// #define ENABLE_UART2_AS_COM2 `

On FabGL dev-board and TTGO VGA32v.1.4 board disabling PSRAM causes the PC emulator to work slower, for some reason:
```
CheckIt "Main System" benchmark, FabGL development board
--------------------------------------------------------
Default (COM1, no setup), PSRAM enabled:     CPU 2.17 times PC-XT; MATH 1.28 times PC-XT
Default (COM1, no setup), PSRAM disabled:    CPU 2.11 times PC-XT; MATH 1.30 times PC-XT
COM1&2 + FlowControl::None, PSRAM enabled:   CPU 2.08 times PC-XT; MATH 1.25 times PC-XT 
COM1&2 + FlowControl::None, PSRAM disabled:  CPU 0.81 times PC-XT; MATH 0.49 times PC-XT 
COM1&2+FlowControl::Software, PSRAM enabled: CPU 2.00 times PC-XT; MATH 1.20 times PC-XT
```