### PR TITLE
Refactor drawChar so it can draw with fixed and variable width fonts.

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -392,9 +392,17 @@ void Canvas::selectFont(FontInfo const * fontInfo)
 }
 
 
-void Canvas::drawChar(int X, int Y, char c)
+void Canvas::drawChar(int X, int Y, char c, bool checkwidth)
 {
-  drawGlyph(X, Y, m_fontInfo->width, m_fontInfo->height, m_fontInfo->data, c);
+  if (checkWidth && fontInfo->chptr) {
+    // variable width.
+    uint8_t const * chptr = fontInfo->data + fontInfo->chptr[(int)c];
+    fontWidth = *chptr++;
+    drawGlyph(X, Y, fontWidth, fontInfo->height, chptr, 0);
+  } else {
+    // fixed width.
+    drawGlyph(X, Y, m_fontInfo->width, m_fontInfo->height, m_fontInfo->data, c);
+  }
 }
 
 
@@ -414,15 +422,7 @@ void Canvas::drawText(FontInfo const * fontInfo, int X, int Y, char const * text
       X = 0;
       Y += fontInfo->height;
     }
-    if (fontInfo->chptr) {
-      // variable width
-      uint8_t const * chptr = fontInfo->data + fontInfo->chptr[(int)(*text)];
-      fontWidth = *chptr++;
-      drawGlyph(X, Y, fontWidth, fontInfo->height, chptr, 0);
-    } else {
-      // fixed width
-      drawGlyph(X, Y, fontInfo->width, fontInfo->height, fontInfo->data, *text);
-    }
+    drawChar(X, Y, *text, /*checkWidth=*/ true);
   }
 }
 

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -22,7 +22,7 @@
   You should have received a copy of the GNU General Public License
   along with FabGL.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 
 #pragma once
 
@@ -298,7 +298,7 @@ public:
    * @param value Pen width (minimum is 1).
    *
    * Example:
-   * 
+   *
    *     Canvas.setPenWidth(4);
    *     Canvas.drawLine(10, 10, 100, 10);
    */
@@ -611,7 +611,7 @@ public:
    *     // Draw a 'C' at position 100, 100
    *     Canvas.drawChar(100, 100, 'C');
    */
-  void drawChar(int X, int Y, char c);
+  void drawChar(int X, int Y, char c, bool checkwidth = false);
 
   /**
    * @brief Draws a string at specified position.


### PR DESCRIPTION
This change is backwards compatible: existing code that called drawChar(X, Y, c) will work exactly as before but now you can call it  as drawChar(X, Y, c, true) to check if it's a fixed or variable width font and draw accordingly.

Calls to drawText(x, y, "%c", c) can now be replaced for the more efficient drawChar(x, y, c, true);