### PR TITLE
Fix 368: fix LineEditor::edit to trigger also CursorDown

### DIFF
--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -5156,7 +5156,7 @@ char const * LineEditor::edit(int maxLength)
 
         // "ESC [ B" : cursor Down
         case 'B':
-          performCursorUp();
+          performCursorDown();
           m_state = 0;
           break;
 


### PR DESCRIPTION
Fix is trivial.
It was just a typo.

